### PR TITLE
Switch DevoxxPhotoSharingDataProvider to use ImageStorageDataProvider.

### DIFF
--- a/conference-impl/build.gradle
+++ b/conference-impl/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.tweetwallfx:tweetwallfx-controls:1.1.+'
     implementation 'org.tweetwallfx:tweetwallfx-conference-spi:1.1.+'
     implementation 'org.tweetwallfx:tweetwallfx-stepengine-api:1.1.+'
+    implementation 'org.tweetwallfx:tweetwallfx-stepengine-dataproviders:1.1.+'
     implementation 'org.tweetwallfx:tweetwallfx-transitions:1.1.+'
     implementation 'org.tweetwallfx:tweetwallfx-utility:1.1.+'
 

--- a/conference-impl/src/main/java/org/tweetwallfx/conference/impl/DevoxxPhotoSharingDataProvider.java
+++ b/conference-impl/src/main/java/org/tweetwallfx/conference/impl/DevoxxPhotoSharingDataProvider.java
@@ -26,46 +26,32 @@ package org.tweetwallfx.conference.impl;
 import static org.tweetwallfx.util.Nullable.nullable;
 
 import java.time.Instant;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
-import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
-import javafx.scene.image.Image;
-
-import org.tweetwallfx.cache.URLContent;
 import org.tweetwallfx.cache.URLContentCacheBase;
 import org.tweetwallfx.conference.spi.util.RestCallHelper;
 import org.tweetwallfx.config.Configuration;
 import org.tweetwallfx.stepengine.api.DataProvider;
 import org.tweetwallfx.stepengine.api.config.StepEngineSettings;
+import org.tweetwallfx.stepengine.dataproviders.ImageStorage;
+import org.tweetwallfx.stepengine.dataproviders.ImageStorageDataProvider;
 
-public class DevoxxPhotoSharingDataProvider implements DataProvider, DataProvider.Scheduled {
+public class DevoxxPhotoSharingDataProvider
+        extends ImageStorageDataProvider.Base
+        implements DataProvider.Scheduled {
 
-    private static final Comparator<SharedPhoto> SHARED_PHOTO_COMPARATOR = Comparator
-            .comparing(SharedPhoto::createdAt)
-            .thenComparing(SharedPhoto::id);
-    private final NavigableSet<SharedPhoto> sharedPhotos = new TreeSet<>(SHARED_PHOTO_COMPARATOR);
+    private static final String SHARED_PHOTO_ID = "sharedPhotoId";
     private final Config config;
     private boolean initialized = false;
 
     private DevoxxPhotoSharingDataProvider(final Config config) {
+        super(config.cacheSize());
         this.config = config;
-    }
-
-    public List<Image> getPhotos(final int amount) {
-        return sharedPhotos.stream()
-                .limit(amount)
-                .map(SharedPhoto::url)
-                .map(URLContentCacheBase.getDefault()::getCachedOrLoad)
-                .map(URLContent::getInputStream)
-                .map(Image::new)
-                .toList();
     }
 
     @Override
@@ -85,52 +71,43 @@ public class DevoxxPhotoSharingDataProvider implements DataProvider, DataProvide
 
     @Override
     public void run() {
-        final Set<SharedPhoto> loadedPhotos = loadPhotos();
-
-        // add loaded images to cache
-        sharedPhotos.addAll(loadedPhotos);
-
-        // ensure cache is sized correctly (from being too large)
-        while (sharedPhotos.size() > config.cacheSize()) {
-            sharedPhotos.removeLast();
-        }
-
-        // set to initialized
+        loadPhotos();
         initialized = true;
     }
 
-    private Set<SharedPhoto> loadPhotos() {
-        final String newestKnowId = Optional.of(sharedPhotos)
-                .filter(Predicate.not(Set::isEmpty))
-                .map(NavigableSet::first)
-                .map(SharedPhoto::id)
-                .orElse(null);
+    private void loadPhotos() {
+        final Access access = getAccess(ImageStorage.DEFAULT_CATEGORY);
+        final Set<String> knownIds = access.getImages(40)
+                .stream()
+                // extract shared photo id
+                .map(is -> is.getAdditionalInfo().get(SHARED_PHOTO_ID))
+                .filter(Objects::nonNull)
+                .map(String.class::cast)
+                .collect(Collectors.toSet());
 
         Optional<PageInfo> pageInfo = Optional.empty();
-        final Set<SharedPhoto> newPhotos = new TreeSet<>(SHARED_PHOTO_COMPARATOR);
+        boolean foundAnyKnownId;
 
         do {
             final Optional<SharedPhotos> requestedData = loadPhotosPage(pageInfo.map(PageInfo::lastVisible).orElse(null));
             pageInfo = requestedData.map(SharedPhotos::pageInfo);
 
             final Optional<List<SharedPhoto>> opSharedPhotos = requestedData.map(SharedPhotos::photos);
-            opSharedPhotos.ifPresent(newPhotos::addAll);
             opSharedPhotos.ifPresent(this::triggerPhotoLoad);
-        } while (pageInfo.map(PageInfo::hasMore).orElse(Boolean.FALSE)
-                && newPhotos.size() < config.cacheSize()
-                && (null == newestKnowId ^ newPhotos.stream().map(SharedPhoto::id).anyMatch(Predicate.isEqual(newestKnowId))));
 
-        return newPhotos;
+            foundAnyKnownId = opSharedPhotos.orElse(List.of()).stream()
+                    .map(SharedPhoto::id)
+                    .anyMatch(knownIds::contains);
+        } while (pageInfo.map(PageInfo::hasMore).orElse(Boolean.FALSE)
+                && access.count() < config.cacheSize()
+                && !foundAnyKnownId);
     }
 
     private void triggerPhotoLoad(final List<SharedPhoto> sharedPhotos) {
         final URLContentCacheBase cacheBase = URLContentCacheBase.getDefault();
-        sharedPhotos.stream()
-                .map(SharedPhoto::url)
-                // process only those that are not yet cached
-                .filter(Predicate.not(cacheBase::hasCachedContent))
-                // add url of photo to be loaded
-                .forEach(cacheBase::putCachedContent);
+        sharedPhotos.forEach(sp -> cacheBase.getCachedOrLoad(
+                sp.url(),
+                uc -> add(uc, sp.createdAt(), Map.of(SHARED_PHOTO_ID, sp.id()))));
     }
 
     private Optional<SharedPhotos> loadPhotosPage(final String lastVisible) {


### PR DESCRIPTION
The pondering pause when starting the mosaic step to the first image being shown has been reduced.


